### PR TITLE
Add original link to response object

### DIFF
--- a/handler.js
+++ b/handler.js
@@ -20,7 +20,7 @@ module.exports.scrape = (event, context, callback) => {
       return response.text();
     })
     .then(body => {
-      let result = { longUrl: originalUrl };
+      let result = { resolvedUrl: originalUrl };
 
       const $ = cheerio.load(body);
       const $title = $('title');

--- a/handler.js
+++ b/handler.js
@@ -4,19 +4,23 @@ const cheerio = require('cheerio');
 const fetch = require('node-fetch');
 
 module.exports.scrape = (event, context, callback) => {
-
-  if (! event || ! event.queryStringParameters || ! event.queryStringParameters.url) {
+  if (
+    !event ||
+    !event.queryStringParameters ||
+    !event.queryStringParameters.url
+  ) {
     return sendResponse(400, 'Missing `url` param');
   }
-
+  let originalUrl;
   console.log(`Fetching: ${event.queryStringParameters.url}`);
 
   fetch(event.queryStringParameters.url)
     .then(response => {
+      originalUrl = response.url;
       return response.text();
     })
     .then(body => {
-      let result = {};
+      let result = { longUrl: originalUrl };
 
       const $ = cheerio.load(body);
       const $title = $('title');
@@ -31,11 +35,9 @@ module.exports.scrape = (event, context, callback) => {
 
         if (name === 'og:title') {
           result.title = value;
-        }
-        else if (name === 'og:description') {
+        } else if (name === 'og:description') {
           result.description = value;
-        }
-        else if (name === 'og:image') {
+        } else if (name === 'og:image') {
           result.image = value;
         }
       }
@@ -59,20 +61,18 @@ module.exports.scrape = (event, context, callback) => {
     let resBody = {};
     if (typeof body === 'object') {
       resBody = body;
-    }
-    else if (typeof body === 'string') {
-      resBody = {message: body};
+    } else if (typeof body === 'string') {
+      resBody = { message: body };
     }
 
     const response = {
       statusCode: status,
       headers: {
-        'Access-Control-Allow-Origin' : '*'
+        'Access-Control-Allow-Origin': '*',
       },
       body: JSON.stringify(resBody),
     };
 
     callback(null, response);
   }
-
 };


### PR DESCRIPTION
This is related to updating utm source of aticle links to breakdown traffic to `advice.shine` by platform source.

https://trello.com/c/ILfGzZt8/94-automatically-append-utm-tags-to-article-links-based-on-the-messaging-platform